### PR TITLE
Add Chinese mirror maven & clojar repositories

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -16,6 +16,9 @@
             [lein-shell "0.5.0"]
             [lein-pprint "1.3.2"]]
 
+  :repositories [["central" "http://maven.aliyun.com/nexus/content/groups/public"]
+                 ["clojars" "https://mirrors.tuna.tsinghua.edu.cn/clojars/"]]
+
   :min-lein-version "2.9.0"
 
   :jvm-opts ["-Xmx1G"]
@@ -99,4 +102,10 @@
 
 
   :prep-tasks [])
+
+;; Disable leiningen strict repository check
+;; https://github.com/clj-commons/pomegranate
+(require 'cemerick.pomegranate.aether)
+(cemerick.pomegranate.aether/register-wagon-factory!
+ "http" #(org.apache.maven.wagon.providers.http.HttpWagon.))
 


### PR DESCRIPTION
I find it's a little hard to fetch dependencies in China without setting up mirror repos. Since this is a region-specific issue, feel free to reject if you think it's unnecessary.

Reference:
[[Clojure] 包管理器leiningen配置国内镜像仓库](https://www.bbsmax.com/A/n2d91bOwdD/)